### PR TITLE
Update readme to handle unsupported devise routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Mount engine for Pingback functionality
 
 ```ruby
 MyApp::Application.routes.draw do
+  devise_for :users, only: [:omniauth_callbacks, :omniauth_authorize]
+
   mount DoorkeeperSsoClient::Engine => "/doorkeeper_sso_client"
 ```
 


### PR DESCRIPTION
The default devise routes shouldn't be usable. If we don't do this then the default devise routes are accessible directly, and it will not follow the SSO flow. 

Also because we're not doing `config.omniauth :xxxxxxx` in `config/devise.rb`. It will not include `Devise::OmniAuth::UrlHelpers` an therefore you'll have problems when you access the default Devise templates that contains `omniauth_authorize_path(resource_name, provider)`
